### PR TITLE
Database RamanDB() and vino integration

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/PyVino.iml
+++ b/.idea/PyVino.iml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/dataSources.xml
+++ b/.idea/dataSources.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="DataSourceManagerImpl" format="xml" multifile-model="true">
+    <data-source source="LOCAL" name="raman" uuid="6d36d5a1-9abb-470b-9c9c-7ea1f0d23aa1">
+      <driver-ref>sqlite.xerial</driver-ref>
+      <synchronize>true</synchronize>
+      <jdbc-driver>org.sqlite.JDBC</jdbc-driver>
+      <jdbc-url>jdbc:sqlite:$PROJECT_DIR$/raman.db</jdbc-url>
+      <working-dir>$ProjectFileDir$</working-dir>
+      <libraries>
+        <library>
+          <url>file://$APPLICATION_CONFIG_DIR$/jdbc-drivers/Xerial SQLiteJDBC/3.34.0/sqlite-jdbc-3.34.0.jar</url>
+        </library>
+      </libraries>
+    </data-source>
+  </component>
+</project>

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,8 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="PyBroadExceptionInspection" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="PyPep8NamingInspection" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="SqlResolveInspection" enabled="false" level="ERROR" enabled_by_default="false" />
+  </profile>
+</component>

--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <settings>
+    <option name="USE_PROJECT_PROFILE" value="false" />
+    <version value="1.0" />
+  </settings>
+</component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.8" project-jdk-type="Python SDK" />
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/PyVino.iml" filepath="$PROJECT_DIR$/.idea/PyVino.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/ramandb.py
+++ b/ramandb.py
@@ -82,7 +82,7 @@ class RamanDB(Database):
             wavelengths, intensities = self.readQEProFile(filePath)
             values = []
             for x,y in zip(wavelengths, intensities):
-                values.append("({0}, {1}, 'raw', 16, {2}, '{3}') ".format(x,y, sampleId, spectrumId))
+                values.append("({0}, {1}, 'raw', {2}, {3}, '{4}') ".format(x,y, wineId, sampleId, spectrumId))
 
             bigStatement = "insert into spectra (wavelength, intensity, dataType, wineId, sampleId, spectrumId) values" + ','.join(values)
             self.execute( bigStatement)

--- a/ramandb.py
+++ b/ramandb.py
@@ -1,12 +1,15 @@
 from dcclab.database import *
 import numpy as np
 import requests
+from BaselineRemoval import BaselineRemoval
 
 class RamanDB(Database):
     url = 'https://www.dropbox.com/s/peowchyj7xyib4w/raman.db?dl=1'
     def __init__(self, writePermission=False):  
         """
         Creates the database object for Raman spectra.
+
+        The information as entered by people is here: https://docs.google.com/spreadsheets/d/1CgXRyIr7q3P26GP8Km4r9LuLH5o2APFj-4B72niTI1g/edit#gid=0
         """
 
         self.databasePath = "raman.db"
@@ -19,7 +22,32 @@ class RamanDB(Database):
 
         self._wavelengths = None
         self.progressStart = None
+        self.constraints = []
         super().__init__(self.databasePath, writePermission=writePermission)
+
+    def showHelp(self):
+        print("""
+        All wines obtained from the group are in this database. Things to know:
+        * Wines are identified with a "wineId" that is A,B,C, .... AA, AB, AC, .... etc.
+        * Each wine has a number a spectrum acquisitions associated with it (typically 30, 60, etc...)
+        * When a Raman spectrum is acquired
+        
+        """)
+
+    def execute(self, statement, bindings=None):
+        """
+        This function with "bindings" is necessary to handle binary data: it cannot be inserted with a string statement.
+        The bindings are explained here: https://zetcode.com/db/sqlitepythontutorial/ and are similar to .format()
+        but are handled properly by the sqlite3 module instead of a python string. Without it, binary data
+        is inserted as a string, which is not good.
+
+        See insertFileContentIntoSources() for an example.
+
+        """
+        if bindings is None:
+            super().execute(statement) # Call the original function from dcclab.database
+        else:
+            self.cursor.execute(statement, bindings)
 
     def downloadDatabase(self):
         r = requests.get(self.url, allow_redirects=True)
@@ -46,14 +74,39 @@ class RamanDB(Database):
 
         return wavelengths
 
+    def getDataTypes(self):
+        self.execute('select dataType from spectra group by dataType')
+        rows = self.fetchAll()
+        dataTypes = []
+        for row in rows:
+            dataTypes.append(row["dataType"])
 
-    def getCountFiles(self):
+        return dataTypes
+
+    def getIdentifiers(self):
+        self.execute(r"select count(*) as count, wineId as id from files group by wineId order by wineId;")
+        rows = self.fetchAll()
+        identifiers = {}
+        for row in rows:
+            id = row["id"]
+            nSamples = row["count"]
+            identifiers[id] = nSamples
+        return identifiers
+
+    def getWinesSummary(self):
+        self.execute(r"select files.wineId,  count(*) as nSamples, wines.* from files inner join wines on wines.wineId = files.wineId group by files.wineId order by files.wineId")
+        rows = self.fetchAll()
+        wines = []
+        for row in rows:
+            wines.append(dict(row))
+        return wines
+
+    def getFileCount(self):
         self.execute(r"select count(*) as count from files")
         rows = self.fetchAll()
         if rows is None:
             return 0
         return rows[0]["count"]
-
 
     def getSpectraPaths(self):
         self.execute("select path from files order by path")
@@ -64,10 +117,23 @@ class RamanDB(Database):
         return paths
 
     def getIntensities(self, limit=None):
+        return self.getSpectraWithWineId(limit=limit)
+
+    def getSpectraWithId(self, dataType=None, limit=None):
+        possibleDataTypes = self.getDataTypes()
+
+        if dataType is None:
+            dataType = 'raw'
+
+        if dataType not in possibleDataTypes:
+            raise ValueError('Possible dataTypes are {0}'.format(possibleDataTypes))
+
         stmnt = """
-        select wavelength, intensity, files.path from spectra 
-        inner join files on files.fid = spectra.fid
-        order by files.path, wavelength """
+        select wavelength, intensity, spectra.spectrumId, wines.* from spectra 
+        inner join files on files.spectrumId = spectra.spectrumId
+        inner join wines on wines.wineId = files.wineId
+        where dataType = '{0}'
+        order by files.path, wavelength """.format(dataType)
 
         wavelengths = self.getWavelengths()
         nWavelengths = len(wavelengths)
@@ -86,14 +152,35 @@ class RamanDB(Database):
             return None
 
         spectra = np.zeros(shape=(nWavelengths, nSamples))
-        wineIdentifiers = [""]*nSamples
+        spectrumIdentifiers = [""]*nSamples
         for i,row in enumerate(rows):
             spectra[i%nWavelengths, i//nWavelengths] = float(row['intensity'])
-            match = re.search(r"([A-Z]+)_?\d+.txt", row["path"])
-            if match is not None:
-                wineIdentifiers[i//nWavelengths] = match.group(1)
+            spectrumIdentifiers[i//nWavelengths] = row['spectrumId']
 
-        return spectra, wineIdentifiers
+        return spectra, spectrumIdentifiers
+
+    def storeCorrectedSpectra(self):
+        spectra, spectrumIds = self.getSpectraWithId()
+        correctedSpectra = self.subtractFluorescence(spectra)
+        for i in range( correctedSpectra.shape[1]):
+            spectrumId = spectrumIds[i]
+            print("Running for spectrum {0}".format(spectrumId))
+            for x,y in zip(self.wavelengths, correctedSpectra[:,i]):
+                self.execute("insert into spectra (wavelength, intensity, spectrumId, dataType, algorithm, dateAdded) values(?, ?, ?, 'fluorescence-corrected', 'BaselineRemoval-degree5', datetime())", (x,y, spectrumId))
+
+    def subtractFluorescence(self, rawSpectra, polynomialDegree=5):
+
+        """
+        Remove fluorescence background from the data.
+        :return: A corrected data without the background.
+        """
+
+        correctedSpectra = np.empty_like(rawSpectra)
+        for i in range(rawSpectra.shape[1]):
+            spectrum = rawSpectra[:, i]
+            correctedSpectra[:, i] = BaselineRemoval(spectrum).IModPoly(polynomialDegree)
+
+        return correctedSpectra
 
     def showProgressBar(self, iteration, total, prefix = '', suffix = '', decimals = 1, length = 100, fill = '█', printEnd = "\r"):
         """

--- a/testDatabase.py
+++ b/testDatabase.py
@@ -23,19 +23,19 @@ class TestBuildDatabase(unittest.TestCase):
 
     def testFileCount(self):
         db = RamanDB()
-        self.assertIsNotNone(db.getCountFiles())
-        self.assertEqual(db.getCountFiles(), 709)
+        self.assertIsNotNone(db.getFileCount())
+        self.assertEqual(db.getFileCount(), 709)
 
     def testFilePaths(self):
         db = RamanDB()
         self.assertIsNotNone(db.getSpectraPaths())
-        self.assertEqual(db.getCountFiles(), len(db.getSpectraPaths()))
+        self.assertEqual(db.getFileCount(), len(db.getSpectraPaths()))
 
     def testGetIntensity(self):
         db = RamanDB()
         matrix, labels = db.getIntensities()
         self.assertIsNotNone(matrix)
-        self.assertEqual(matrix.shape, (len(db.wavelengths), db.getCountFiles()))
+        self.assertEqual(matrix.shape, (len(db.wavelengths), db.getFileCount()))
 
     @unittest.skip("Ok, tested")
     def testDownload(self):
@@ -65,6 +65,41 @@ class TestBuildDatabase(unittest.TestCase):
             statement = "update spectra set fid={0} where md5='{1}'".format(record["fid"], record["md5"])
             db.execute(statement)
 
+    @unittest.skip("done")
+    def testBuildWineIdAndSampleId(self):
+        db.execute('update files set sampleId=substr(path,18,2) where path like "%\_%" ESCAPE "\"')
+
+    def testWineIdentifiers(self):
+        db = RamanDB()
+        print(db.getIdentifiers())
+
+    def testWinesSummary(self):
+        db = RamanDB()
+        wineSummary = db.getWinesSummary()
+        print(wineSummary)
+
+    def testStoreCorrectedSpectra(self):
+        db = RamanDB(writePermission=False)
+        db.storeCorrectedSpectra()
+
+    def testDataTypes(self):
+        db = RamanDB(writePermission=False)
+        print(db.getDataTypes())
+
+    def testGetSpectraValidType(self):
+        db = RamanDB(writePermission=False)
+        spectra, spectrumIds = db.getSpectraWithId(dataType='raw')
+        self.assertIsNotNone(spectra)
+
+    def testGetSpectraValidTypeFluorescence(self):
+        db = RamanDB(writePermission=False)
+        spectra, spectrumIds = db.getSpectraWithId(dataType='fluorescence-corrected')
+        self.assertIsNotNone(spectra)
+
+    def testGetSpectraInvalidType(self):
+        db = RamanDB(writePermission=False)
+        with self.assertRaises(ValueError):
+            spectra = db.getSpectraWithId(dataType='unknown')
 
 if __name__ == "__main__":
     unittest.main()

--- a/testDatabase.py
+++ b/testDatabase.py
@@ -8,8 +8,8 @@ import re
 
 class TestRamanDatabase(unittest.TestCase):
     def setUp(self):
-        self.db = RamanDB()
-        # self.db = RamanDB("mysql://127.0.0.1/root@raman")
+        # self.db = RamanDB()
+        self.db = RamanDB("mysql://127.0.0.1/root@raman")
         self.assertIsNotNone(self.db)
 
     @unittest.skip("Now in setUp")
@@ -99,7 +99,7 @@ class TestRamanDatabase(unittest.TestCase):
         self.assertTrue(self.db.executeCount("select count(*) as count from spectra") > 0)
 
     def test13InsertAllCorrectedSpectra(self):
-        self.db.execute("select distinct spectrumId from spectra where dataType='raw' and spectrumId not in (select spectrumId from spectra where dataType='fluorescence-corrected')")
+        self.db.execute("select distinct spectrumId from spectra where spectrumId not in (select spectrumId from spectra where dataType='fluorescence-corrected')")
         records = self.db.fetchAll()
         if len(records) == 0:
             self.skipTest("All corrected spectra exist in the database")
@@ -107,6 +107,8 @@ class TestRamanDatabase(unittest.TestCase):
         for record in records:
             spectrumId = record["spectrumId"]
             spectrum, labels = self.db.getSpectrum(dataType='raw', spectrumId=spectrumId)
+            if spectrum is None:
+                continue
             degree = 100
             correctedSpectrum = self.db.subtractFluorescence(spectrum, polynomialDegree=degree)
             print(spectrumId)

--- a/testDatabase.py
+++ b/testDatabase.py
@@ -8,8 +8,8 @@ import re
 
 class TestRamanDatabase(unittest.TestCase):
     def setUp(self):
-        # self.db = RamanDB()
-        self.db = RamanDB("mysql://127.0.0.1/root@raman")
+        self.db = RamanDB()
+        # self.db = RamanDB("mysql://127.0.0.1/root@raman")
         self.assertIsNotNone(self.db)
 
     @unittest.skip("Now in setUp")

--- a/testDatabase.py
+++ b/testDatabase.py
@@ -88,27 +88,15 @@ class TestBuildDatabase(unittest.TestCase):
         self.assertEqual(len(intensities), 1044)
 
     @unittest.skip("Done to fix a bad import, no need to redo")
-    def testInsertQSpectra(self):
+    def testInsertAllSpectra(self):
         db = RamanDB()
-
         dataDir = 'originaldata'
-        filePaths = os.listdir(dataDir)
-        for filename in filePaths:
-            match = re.search(r'Q(\d+)', filename)
-            if match is None:
-                continue
-            filePath = os.path.join(dataDir, filename)
-            print("Inserting {0}".format( filePath ))
-            sampleId = int(match.group(1))
-            spectrumId = "0016-{0:04d}".format(sampleId)
+        filenames = os.listdir(dataDir)
+        filePaths = []
+        for filename in filenames:
+            filePaths.append(os.path.join(dataDir, filename))
 
-            wavelengths, intensities = db.readQEProFile(filePath)
-            values = []
-            for x,y in zip(wavelengths, intensities):
-                values.append("({0}, {1}, 'raw', 16, {2}, '{3}') ".format(x,y, sampleId, spectrumId))
-
-            bigStatement = "insert into spectra (wavelength, intensity, dataType, wineId, sampleId, spectrumId) values" + ','.join(values)
-            db.execute( bigStatement)
+        db.insertSpectralDataFromFiles(filePaths)
 
     @unittest.skip("Done, no need to redo.")
     def testAddFileIdToDatabase(self):
@@ -141,6 +129,7 @@ class TestBuildDatabase(unittest.TestCase):
         valueRecord = db.fetchOne()
         self.assertEqual(valueRecord["count"], totalNumberOfSpectra*len(db.getWavelengths()))
 
+    @unittest.skip("Not ready")
     def testStoreCorrectedSpectra(self):
         db = RamanDB()
         db.storeCorrectedSpectra()
@@ -165,11 +154,6 @@ class TestBuildDatabase(unittest.TestCase):
     def testDataTypes(self):
         db = RamanDB()
         self.assertTrue('raw' in db.getDataTypes())
-
-    def testGetSpectraValidType(self):
-        db = RamanDB()
-        spectra, spectrumIds = db.getSpectraWithId(dataType='raw')
-        self.assertIsNotNone(spectra)
 
     def testGetSpectraValidTypeFluorescence(self):
         db = RamanDB()

--- a/testDatabase.py
+++ b/testDatabase.py
@@ -149,13 +149,14 @@ class TestRamanDatabase(unittest.TestCase):
         with self.assertRaises(ValueError):
             spectra = self.db.getSpectraWithId(dataType='unknown')
 
+    @unittest.skip("Only on dccote's computer")
     def test20DatabaseMySQLLocal(self):
         db = RamanDB("mysql://127.0.0.1/root@raman")
         self.assertIsNotNone(db)
         self.assertIsNotNone(db.getWavelengths())
 
     def test21Wavenumbers(self):
-        print(self.db.wavenumbers)
+        self.assertIsNotNone(self.db.wavenumbers)
 
     def test22Mask(self):
         print(sum(self.db.wavelengthMask))

--- a/testDatabase.py
+++ b/testDatabase.py
@@ -146,6 +146,8 @@ class TestBuildDatabase(unittest.TestCase):
         if 'fluorescence-corrected' in db.getDataTypes():
             spectra, spectrumIds = db.getSpectraWithId(dataType='fluorescence-corrected')
             self.assertIsNotNone(spectra)
+        else:
+            self.skipTest("No background-corrected spectra in database")
 
     def testGetSpectraInvalidType(self):
         db = RamanDB()

--- a/testDatabase.py
+++ b/testDatabase.py
@@ -105,8 +105,11 @@ class TestRamanDatabase(unittest.TestCase):
 
     def testInsertAllCorrectedSpectra(self):
         db = RamanDB()
-        db.execute("select distinct spectrumId from spectra")
+        db.execute("select distinct spectrumId from spectra where spectrumId not in (select spectrumId from spectra where dataType='fluorescence-corrected')")
         records = db.fetchAll()
+        if len(records) == 0:
+            self.skipTest("All corrected spectra exist in the database")
+
         for record in records:
             spectrumId = record["spectrumId"]
             spectrum, labels = db.getSpectrum(dataType='raw', spectrumId=spectrumId)

--- a/testDatabase.py
+++ b/testDatabase.py
@@ -116,10 +116,6 @@ class TestBuildDatabase(unittest.TestCase):
     def testBuildWineIdAndSampleId(self):
         db.execute('update files set sampleId=substr(path,18,2) where path like "%\_%" ESCAPE "\"')
 
-    def testWineIdentifiers(self):
-        db = RamanDB()
-        print(db.getIdentifiers())
-
     def testWinesSummary(self):
         db = RamanDB()
         wineSummary = db.getWinesSummary()
@@ -129,7 +125,7 @@ class TestBuildDatabase(unittest.TestCase):
         valueRecord = db.fetchOne()
         self.assertEqual(valueRecord["count"], totalNumberOfSpectra*len(db.getWavelengths()))
 
-    @unittest.skip("Not ready")
+    @unittest.skip("This function is not ready")
     def testStoreCorrectedSpectra(self):
         db = RamanDB()
         db.storeCorrectedSpectra()
@@ -141,24 +137,15 @@ class TestBuildDatabase(unittest.TestCase):
         for record in records:
             print(record)
 
-    # def testStoreSingleSpectrum(self):
-    #     spectra, spectrumIds = self.getSpectraWithId(dataType='raw')
-    #     correctedSpectra = self.subtractFluorescence(spectra)
-    #     for i in range( correctedSpectra.shape[1]):
-    #         spectrumId = spectrumIds[i]
-    #         print("Running for spectrum {0}".format(spectrumId))
-    #         for x,y in zip(self.wavelengths, correctedSpectra[:,i]):
-    #             # self.execute("insert into spectra (wavelength, intensity, spectrumId, dataType, algorithm, dateAdded) values(?, ?, ?, 'fluorescence-corrected', 'BaselineRemoval-degree5', datetime())", (x,y, spectrumId))
-    #             self.execute("insert into spectra (wavelength, intensity, spectrumId, dataType, algorithm, dateAdded) values(%s, %s, %s, 'fluorescence-corrected', 'BaselineRemoval-degree5', datetime())",(x, y, spectrumId))
-
     def testDataTypes(self):
         db = RamanDB()
         self.assertTrue('raw' in db.getDataTypes())
 
     def testGetSpectraValidTypeFluorescence(self):
         db = RamanDB()
-        spectra, spectrumIds = db.getSpectraWithId(dataType='fluorescence-corrected')
-        self.assertIsNotNone(spectra)
+        if 'fluorescence-corrected' in db.getDataTypes():
+            spectra, spectrumIds = db.getSpectraWithId(dataType='fluorescence-corrected')
+            self.assertIsNotNone(spectra)
 
     def testGetSpectraInvalidType(self):
         db = RamanDB()

--- a/testVino.py
+++ b/testVino.py
@@ -1,0 +1,90 @@
+import unittest
+import numpy as np
+from dcclab import Database
+import os
+from ramandb import RamanDB
+import requests
+import matplotlib.pyplot as plt
+from vino import vinoPCA
+
+class TestVInoClass(unittest.TestCase):
+    @unittest.skip("NOt now")
+    def testInit(self):
+        iterable = [31, 30, 30, 30, 80, 31, 33, 31, 30, 30, 30, 30, 30, 30, 30, 30, 104, 30, 30] # sans vin blanc parceque ça shit le aspect ratio
+        total = sum(iterable)
+
+        # Data = np.genfromtxt('/Users/Shooshoo/PycharmProjects/PCA_DCCLab/DataVino_Sorted.csv', delimiter=',')
+        db = RamanDB()
+        data, labels = db.getIntensities()
+        wavelengths = db.getWavelengths()
+        data = np.cat(wavelengths, wavelengths, data[:,0:total])
+        self.assertEqual(data.shape[1], total)
+        my_Spectrums = vinoPCA(data, iterable)
+
+        self.assertIsNotNone(my_Spectrums)
+
+    def testRemoveFluo(self):
+        iterable = [31, 30, 30, 30, 80, 31, 33, 31, 30, 30, 30, 30, 30, 30, 30, 30, 104, 30, 30] # sans vin blanc parceque ça shit le aspect ratio
+        total = sum(iterable)
+
+        # I need to remove this function, I don't have access to the csv file.
+        # Data = np.genfromtxt('/Users/Shooshoo/PycharmProjects/PCA_DCCLab/DataVino_Sorted.csv', delimiter=',')
+        # After a bit of playing around: column 0 is not used, column 1 is the wavelengths, then its
+        # the data
+        db = RamanDB()
+        data, labels = db.getIntensities()
+        wavelengths = db.getWavelengths()
+        wavelengths = np.expand_dims(wavelengths, 1)
+
+        data = np.concatenate( (wavelengths, wavelengths, data[:,0:total]), axis=1 )
+        # self.assertEqual(data.shape[1], total)
+        my_Spectrums = vinoPCA(data, iterable)
+
+        self.assertIsNotNone(my_Spectrums)
+
+        my_Spectrums.removeFLuo(my_Spectrums.Data)
+
+
+    def testDoPCA(self):
+        iterable = [31, 30, 30, 30, 80, 31, 33, 31, 30, 30, 30, 30, 30, 30, 30, 30, 104, 30, 30] # sans vin blanc parceque ça shit le aspect ratio
+        total = sum(iterable)
+
+        # Data = np.genfromtxt('/Users/Shooshoo/PycharmProjects/PCA_DCCLab/DataVino_Sorted.csv', delimiter=',')
+        db = RamanDB()
+        data, labels = db.getIntensities()
+        wavelengths = db.getWavelengths()
+        wavelengths = np.expand_dims(wavelengths, 1)
+
+        data = np.concatenate( (wavelengths, wavelengths, data[:,0:total]), axis=1 )
+        # self.assertEqual(data.shape[1], total)
+        my_Spectrums = vinoPCA(data, iterable)
+
+        self.assertIsNotNone(my_Spectrums)
+
+        my_Spectrums.doPCA(10)
+        my_Spectrums.showTransformedData3D()
+        my_Spectrums.showTransformedData2D()
+        my_Spectrums.showEigenvectors()
+
+    # def testInitDB(self):
+    #     self.assertIsNotNone(vinoPCA().db)
+
+    # def testColormap(self):
+    #     vino = vinoPCA()
+    #     cm = vino.getColorMap()
+    #     self.assertIsNotNone(cm)
+    #     spectra, labels = vino.db.getIntensities()
+    #     self.assertEqual(len(cm), len(labels))
+
+    # def testOneSpectrum(self):
+    #     vino = vinoPCA()
+    #     spectra, labels = vino.db.getIntensities()
+    #     plt.plot(spectra[:,1])
+    #     newSpectra = vino.removeFLuo(spectra)
+    #     print(newSpectra)
+    #     # plt.plot(newSpectra)
+    #     # plt.show()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/testVino.py
+++ b/testVino.py
@@ -64,7 +64,7 @@ class TestVInoClass(unittest.TestCase):
         vino = vinoPCA()
         cm = vino.getColorMap()
         self.assertIsNotNone(cm)
-        spectra, labels = vino.db.getIntensities()
+        spectra, labels = vino.db.getSpectraWithId()
         self.assertEqual(len(cm), len(labels))
 
     # def testOneSpectrum(self):

--- a/testVino.py
+++ b/testVino.py
@@ -31,33 +31,15 @@ class TestVInoClass(unittest.TestCase):
         # Data = np.genfromtxt('/Users/Shooshoo/PycharmProjects/PCA_DCCLab/DataVino_Sorted.csv', delimiter=',')
         # After a bit of playing around: column 0 is not used, column 1 is the wavelengths, then its
         # the data
-        db = RamanDB()
-        data, labels = db.getIntensities()
-        wavelengths = db.getWavelengths()
-        wavelengths = np.expand_dims(wavelengths, 1)
-
-        data = np.concatenate( (wavelengths, wavelengths, data[:,0:total]), axis=1 )
-        # self.assertEqual(data.shape[1], total)
-        my_Spectrums = vinoPCA(data, iterable)
+        my_Spectrums = vinoPCA()
 
         self.assertIsNotNone(my_Spectrums)
 
-        my_Spectrums.removeFLuo(my_Spectrums.Data)
+        my_Spectrums.subtractFluorescence()
 
 
     def testDoPCA(self):
-        iterable = [31, 30, 30, 30, 80, 31, 33, 31, 30, 30, 30, 30, 30, 30, 30, 30, 104, 30, 30] # sans vin blanc parceque ça shit le aspect ratio
-        total = sum(iterable)
-
-        # Data = np.genfromtxt('/Users/Shooshoo/PycharmProjects/PCA_DCCLab/DataVino_Sorted.csv', delimiter=',')
-        db = RamanDB()
-        data, labels = db.getIntensities()
-        wavelengths = db.getWavelengths()
-        wavelengths = np.expand_dims(wavelengths, 1)
-
-        data = np.concatenate( (wavelengths, wavelengths, data[:,0:total]), axis=1 )
-        # self.assertEqual(data.shape[1], total)
-        my_Spectrums = vinoPCA(data, iterable)
+        my_Spectrums = vinoPCA()
 
         self.assertIsNotNone(my_Spectrums)
 

--- a/testVino.py
+++ b/testVino.py
@@ -78,12 +78,12 @@ class TestVInoClass(unittest.TestCase):
     # def testInitDB(self):
     #     self.assertIsNotNone(vinoPCA().db)
 
-    # def testColormap(self):
-    #     vino = vinoPCA()
-    #     cm = vino.getColorMap()
-    #     self.assertIsNotNone(cm)
-    #     spectra, labels = vino.db.getIntensities()
-    #     self.assertEqual(len(cm), len(labels))
+    def testColormap(self):
+        vino = vinoPCA()
+        cm = vino.getColorMap()
+        self.assertIsNotNone(cm)
+        spectra, labels = vino.db.getIntensities()
+        self.assertEqual(len(cm), len(labels)-9)
 
     # def testOneSpectrum(self):
     #     vino = vinoPCA()

--- a/testVino.py
+++ b/testVino.py
@@ -83,7 +83,7 @@ class TestVInoClass(unittest.TestCase):
         cm = vino.getColorMap()
         self.assertIsNotNone(cm)
         spectra, labels = vino.db.getIntensities()
-        self.assertEqual(len(cm), len(labels)-9)
+        self.assertEqual(len(cm), len(labels))
 
     # def testOneSpectrum(self):
     #     vino = vinoPCA()

--- a/testVino.py
+++ b/testVino.py
@@ -66,6 +66,15 @@ class TestVInoClass(unittest.TestCase):
         my_Spectrums.showTransformedData2D()
         my_Spectrums.showEigenvectors()
 
+    def testvinoPCANoArgument(self):
+        my_Spectrums = vinoPCA()
+        self.assertIsNotNone(my_Spectrums)
+
+        my_Spectrums.doPCA(10)
+        my_Spectrums.showTransformedData3D()
+        my_Spectrums.showTransformedData2D()
+        my_Spectrums.showEigenvectors()
+
     # def testInitDB(self):
     #     self.assertIsNotNone(vinoPCA().db)
 

--- a/testVino.py
+++ b/testVino.py
@@ -70,7 +70,7 @@ class TestVInoClass(unittest.TestCase):
         my_Spectrums = vinoPCA()
         self.assertIsNotNone(my_Spectrums)
 
-        my_Spectrums.doPCA(10)
+        my_Spectrums.doPCA(3)
         my_Spectrums.showTransformedData3D()
         my_Spectrums.showTransformedData2D()
         my_Spectrums.showEigenvectors()

--- a/vino.py
+++ b/vino.py
@@ -8,7 +8,7 @@ from ramandb import RamanDB
 
 class vinoPCA:
 
-    def __init__(self, Data=None, numberOfEachSamples=None):
+    def __init__(self):
 
         """
         :param Data: The data on wich PCA should be done.
@@ -20,10 +20,9 @@ class vinoPCA:
         self.data, self.labels = self.db.getIntensities()
         self.wavelengths = self.db.getWavelengths()
 
-        # TO BE REMOVED
-        self.data = self.data[200:1000, 0:700]
-        self.labels = self.labels[0:700]
-        self.wavelengths = self.wavelengths[200:1000]
+        self.wavelengthMask = range(200, 1000)
+        self.data = self.data[self.wavelengthMask, :]
+        self.wavelengths = self.wavelengths[self.wavelengthMask]
 
     def getColorMap(self):
 
@@ -44,12 +43,11 @@ class vinoPCA:
 
         return np.array(colormap)
 
-    def removeFLuo(self, Data=None):
+    def subtractFluorescence(self):
 
         """
-        Remove fluorescence background from the data given.
-        :param Data: The Data from witch you wish to remove fluo background.
-        :return: A new set of Data without the background.
+        Remove fluorescence background from the data.
+        :return: A corrected data without the background.
         """
 
         polynomial_degree = 5
@@ -67,11 +65,9 @@ class vinoPCA:
         :param n: number of componants to get from the PCA
         :return: Returns nothing. Just creats an array of the transformed datas into the new vector space
         """
-        new_Datas = self.removeFLuo()
-        # new_Datas = self.Data[:,0:-1]
-        new_Datas = np.transpose(new_Datas)
-        self.X_PCA = PCA(n_components=n)
-        self.X_reduced = self.X_PCA.fit_transform(new_Datas)
+        self.pca = PCA(n_components=n)
+        correctedData = self.subtractFluorescence()
+        self.X_reduced = self.pca.fit_transform(correctedData.T)
 
     def showTransformedData3D(self):
 
@@ -128,7 +124,7 @@ class vinoPCA:
         :return: an array of n eigenvector
         """
 
-        return self.X_PCA.components_.transpose()
+        return self.pca.components_.transpose()
 
     def showEigenvectors(self):
 
@@ -138,13 +134,13 @@ class vinoPCA:
         """
         plt.figure(3)
         plt.title('1st eigenvector')
-        plt.plot(self.X_PCA.components_.transpose()[:, 0])
+        plt.plot(self.pca.components_.transpose()[:, 0])
         plt.figure(4)
         plt.title('2nd eigenvector')
-        plt.plot(self.X_PCA.components_.transpose()[:, 1])
+        plt.plot(self.pca.components_.transpose()[:, 1])
         plt.figure(5)
         plt.title('3rd eigenvector')
-        plt.plot(self.X_PCA.components_.transpose()[:, 2])
+        plt.plot(self.pca.components_.transpose()[:, 2])
         plt.show()
 
     def getTransformedDatas(self):
@@ -163,7 +159,7 @@ class vinoPCA:
         :return: array of the scree values, from most important to least
         """
 
-        return self.X_PCA.explained_variance_ratio_
+        return self.pca.explained_variance_ratio_
 
     def plotScreeValues(self):
 

--- a/vino.py
+++ b/vino.py
@@ -16,12 +16,6 @@ class vinoPCA:
         """
 
         self.db = RamanDB()
-        self.db.execute("select count(*) as count, substr(path,16,1) as id from files where id != 'T' group by id order by id")
-        records = self.db.fetchAll()
-        numberOfEachSamples = []
-        for record in records:
-            numberOfEachSamples.append(record["count"])
-        total = sum(numberOfEachSamples)
 
         self.data, self.labels = self.db.getIntensities()
         self.wavelengths = self.db.getWavelengths()
@@ -33,19 +27,17 @@ class vinoPCA:
         :return: Return a colormap to visualise different samples on the plot.
         """
 
-        spectra, labels = self.db.getIntensities()
-
-        uniqueLabelsInOrder = sorted(set(labels))
+        uniqueLabelsInOrder = sorted(set(self.labels))
         possibleColorsInOrder = range(len(uniqueLabelsInOrder))
         colors = {}
         for identifier, color in zip(uniqueLabelsInOrder, possibleColorsInOrder):
             colors[identifier] = color*5
 
         colormap = []
-        for identifier in labels:
+        for identifier in self.labels:
             colormap.append(colors[identifier])
 
-        return np.array(colormap[0:700])
+        return np.array(colormap)
 
     def removeFLuo(self, Data):
 
@@ -92,7 +84,7 @@ class vinoPCA:
         :return: Returns nothing. Just creats an array of the transformed datas into the new vector space
         """
         wavelengths = np.expand_dims(self.wavelengths, 1)
-        Data = np.concatenate((wavelengths, wavelengths, self.data[:, 0:total]), axis=1)
+        Data = np.concatenate((wavelengths, wavelengths, self.data[:, 0:700]), axis=1)
 
         new_Datas = self.removeFLuo(Data)
         # new_Datas = self.Data[:,0:-1]

--- a/vino.py
+++ b/vino.py
@@ -44,7 +44,7 @@ class vinoPCA:
         nm = Data[:, 1]
         cm = 1 / (632.8e-9) - 1 / (nm * 1e-9)
         size = np.ma.size(Data, 1)
-        polynomial_degree = 100
+        polynomial_degree = 5
         filtered_datas = np.zeros(shape=(800, size - 1))
 
         # for column in range(2, size):
@@ -79,6 +79,7 @@ class vinoPCA:
         """
 
         new_Datas = self.removeFLuo(self.Data)
+        # new_Datas = self.Data[:,0:-1]
         new_Datas = np.transpose(new_Datas)
         self.X_PCA = PCA(n_components=n)
         self.X_reduced = self.X_PCA.fit_transform(new_Datas[1:, :])

--- a/vino.py
+++ b/vino.py
@@ -9,15 +9,9 @@ from ramandb import RamanDB
 class vinoPCA:
 
     def __init__(self):
-
-        """
-        :param Data: The data on wich PCA should be done.
-        :param colormap: An iterable that contains how many of each samples there is in Data, in the good order.
-        """
-
         self.db = RamanDB()
-
-        self.data, self.labels = self.db.getIntensities()
+        self.constraints = []
+        self.data, self.labels = self.db.getSpectraWithLabels()
         self.wavelengths = self.db.getWavelengths()
 
         self.wavelengthMask = range(200, 1000)

--- a/vino.py
+++ b/vino.py
@@ -11,7 +11,11 @@ class vinoPCA:
     def __init__(self):
         self.db = RamanDB()
         self.constraints = []
-        self.data, self.labels = self.db.getSpectraWithLabels()
+        self.data, self.labels = self.db.getSpectraWithId(dataType='raw')
+        self.correctedData, correctedLabel = self.db.getSpectraWithId(dataType='fluorescence-corrected')
+        if self.labels != correctedLabel:
+            raise ValueError('Not all spectra are corrected')
+
         self.wavelengths = self.db.getWavelengths()
 
         self.wavelengthMask = range(200, 1000)

--- a/vino.py
+++ b/vino.py
@@ -18,7 +18,7 @@ class vinoPCA:
 
         self.wavelengths = self.db.getWavelengths()
 
-        self.wavelengthMask = range(200, 1000)
+        self.wavelengthMask = self.db.wavelengthMask
         self.data = self.data[self.wavelengthMask, :]
         self.wavelengths = self.wavelengths[self.wavelengthMask]
 

--- a/vino.py
+++ b/vino.py
@@ -21,15 +21,10 @@ class vinoPCA:
         numberOfEachSamples = []
         for record in records:
             numberOfEachSamples.append(record["count"])
-        # iterable = [31, 30, 30, 30, 80, 31, 33, 31, 30, 30, 30, 30, 30, 30, 30, 30, 104, 30,
-        #             30]  # sans vin blanc parceque ça shit le aspect ratio
         total = sum(numberOfEachSamples)
 
-        data, labels = self.db.getIntensities()
-        wavelengths = self.db.getWavelengths()
-        wavelengths = np.expand_dims(wavelengths, 1)
-        self.Data = np.concatenate((wavelengths, wavelengths, data[:, 0:total]), axis=1)
-        self.numberOfEachSamples = numberOfEachSamples
+        self.data, self.labels = self.db.getIntensities()
+        self.wavelengths = self.db.getWavelengths()
 
     def getColorMap(self):
 
@@ -96,8 +91,10 @@ class vinoPCA:
         :param n: number of componants to get from the PCA
         :return: Returns nothing. Just creats an array of the transformed datas into the new vector space
         """
+        wavelengths = np.expand_dims(self.wavelengths, 1)
+        Data = np.concatenate((wavelengths, wavelengths, self.data[:, 0:total]), axis=1)
 
-        new_Datas = self.removeFLuo(self.Data)
+        new_Datas = self.removeFLuo(Data)
         # new_Datas = self.Data[:,0:-1]
         new_Datas = np.transpose(new_Datas)
         self.X_PCA = PCA(n_components=n)

--- a/wines.txt
+++ b/wines.txt
@@ -1,0 +1,27 @@
+A	2022/01/12	Wine	Sirius Bordeaux 2018	https://www.saq.com/en/223537	VPN	France		Merlot, Cabernet Sauvignon	2.2	red	13
+B	2022/01/12	Wine	Ménage à Trois 2019	https://www.saq.com/en/10709152	VPN	United States		Cabernet Sauvignon	4.3	red	13.5
+C	2022/01/22	Wine	Woodbridge by Robert Mondavi	https://www.saq.com/en/48611	VPN	United States		Cabernet Sauvignon	7.3	red	13.5
+D	2022/01/28	Wine	Les Jamelles Pinot Noir Pays d'Oc	https://www.saq.com/en/10802904	VPN	France		point noir	4	red	13
+E	2022/01/27	Wine	Monasterio de las Vinas	https://www.saq.com/en/854422	VPN	Spain		70% Garnacha, 20% Tempranillo, 10% Carinena	2.1	red	13.5
+F	2022/02/05	Wine	Revolution	https://www.saq.com/en/12166892	EP	United States		Ruby cabernet 50 %, Carignan 32 %, Syrah 18 %	10	red	13.5
+G	2022/02/12	Wine	Milhistoraise	https://www.saq.com/en/13794111	EP	Spain		Grenache	1.7	red	14
+H	2022/02/13	Wine	Wallaroo Trail Shiraz	https://www.saq.com/en/12498459	EP	Australia		Shiraz 85 %, Cabernet sauvignon 10 %, Petit verdot 5 %	11	red	13.5
+I	2022/02/13	Wine	Toro loco	https://futailles.com/en/products/wine/red/toro-loco	EP	Spain		Tempranillo	0	red	12.5
+J	2022/02/13	Wine	Cantini	https://vinstriani.com/produits/cantini-rouge.html	EP	Italy		Sangiovese, Montepulciano, and Cabernet Sauvignon	-	red	12
+K	2022/02/13	Wine	Nicolas laloux	https://www.vinsenepicerie.com/en/nicolas-laloux-1/	EP	Ontario.Canada		Cabernet Sauvignon	-	red	12.5
+L	2022/02/13	Wine	smoky bay SHIRAZ	https://www.lcbo.com/webapp/wcs/stores/servlet/en/lcbo/red-wine-14001/smoky-bay-shiraz-17650#.YguvavXMIUo	EP	Australia		Shiraz	10	red	13
+M	2022/02/13	Wine	Dolce Venti	https://futailles.com/en/products/wine/red/dolce-venti	EP	Italy		Merlot	-	red	11.5
+N	2022/02/13	Wine	Aroma mi Amore	https://vinsarista.com/en/produit/wines/aroma-mi-amore/aroma-mi-amore-red-wine/	EP	Italy		Refosco	-	red	14.5
+O	2022/02/19	Wine	Sonho Aragonez	https://www.vivino.com/CA/en/sonho-aragonez/w/5905886	EP	Portugal		Aragonez		red	12.5
+P	2022/02/27	Wine	Double vie	https://vinsarista.com/en/produit/wines/double-vie/red-wine/	EP	Canada				red	12
+Q	2022/02/28	Wine	Danza	https://www.iga.net/en/product/wineargentinian-red-bonarda/00000_000000082424300222	EP	Argentina		Douce noir		red	13.7
+R	2022/02/23	Wine	bu	https://www.iga.net/en/product/winered-rosso-terre-sicilaine-bio-it/00000_000000005604913702	EP	Italy		Nero d'Avola 70% + Merlot 20% + Syrah 10%		red	12.5
+S	2022/02/24	Wine	Croix d'Or	https://futailles.com/en/products/wine/red/croix-dor	EP	Moldavie		pinot noir		red	12.5
+T	2022/02/18	Wine	AUFKELLEREIEN	https://www.iga.net/fr/produit/vin-blancallemagne---fruite-et-doux-9--alcool---18-ans--/00000_000000005604980687	AR	Allemagne				white	9
+U	2022/02/15	Wine	Macon Lugny les Cray	https://www.saq.com/en/13319061	DC	France	Bourgogne			white	
+V	2022/02/16	Wine	Brumont Cotes de Gascogne	https://www.saq.com/en/548883	DC	France		Sauvignon, Gros Manseng		white	12
+W	2022/02/18	Wine	Piuze	https://www.saq.com/en/14853741	DC	France		Chardonnay		white	12
+X	2022/02/19	Wine	Chateau de Maligny	https://www.saq.com/en/560763	DC	France	Chablis	Chardonnay		white	12.5
+Y	2022/02/21	Wine	L'impromptu	https://www.saq.com/en/13343264	DC	France		Gamay		red	14
+Z	2022/02/22	Wine	Sancerres Aurore Dezat	https://www.saq.com/en/13992897	DC	France	Sancerre	Chardonnay	1.6	white	12.5
+AA	2022/02/26	Wine	Lord de la Ragotiere	https://www.saq.com/en/10690501	DC	France		Chardonnay		white	12


### PR DESCRIPTION
# Context

I created a database `RamanDB()` that can be used to obtain the spectra with some constraints (color, 'raw' or 'corrected'). You must have the dcclab module (`pip install dcclab`).
The actual database is on cafeine and can be accessed remotely without problems (SSH tunnel, automatic, using account dcclab). It makes use of the module `keyring` that will store the password in the system keychain (install with `pip install keyring`) and `sshtunnel` (install with `pip install sshtunnel`). If the password is not found, it will tell you how to add it with a simple command.

# Usage
```
# In the same directory as ramandb.py
from ramandb import RamanDB
db = RamanDB()
spectra, labels = db.getSpectraWithId(dataType='raw', color='white')
# spectra is a numpy array, labels are the column labels
correctedSpectra = db.subtractFluorescence(spectra, polynomialDegree=10)
```
With the basic functions of `RamanDB()`, it is possible to reconstruct the database from scratch if needed. 

# Caveats
The database has been patially integrated in `vino.py`, but it is not complete.
Many checks will be added to `RamanDB` and the MySQL database schema to maintain the coherence of the data.

